### PR TITLE
add: Carousel option can be disabled for specific styles

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # Elemental Bootstrap Blocks
 
+## Blocks
 This Repository provides a set of base bootstrap blocks which are used in a
 silverstripe-elemental setup.
 
@@ -19,5 +20,11 @@ They lack any template, so you need to provide the following templates in the
 * [MapBlock](src/Element/MapBlock.php) ([docs](docs/MapBlock.md))
 * [TabSetBlock](src/Element/TabSetBlock.php)
 
-## Blog
+### Blog
 See [the docs](docs/BlogBlocks.md).
+
+
+## Extensions
+This module supplies some extensions to add functionality to blocks where needed.
+
+* [UseCarouselExtension](docs/extensions/UseCarouselExtension.md)

--- a/docs/extensions/UseCarouselExtension.md
+++ b/docs/extensions/UseCarouselExtension.md
@@ -1,0 +1,17 @@
+# UseCarouselExtension
+
+This extension adds fields to control an eventual carousel / slider display.
+
+## Added Fields
+
+* `UseCarousel`: If enabled, the block in question should render its contents
+in a slider or carousel.
+* `UseCarouselAutoplay`: If enabled, the block should have an autoplay enabled.
+
+## Config Options
+
+Config options are set on the block to which the extension is applied.
+
+| Name                          | Default | Description                                                                                                                                                                                  |
+| ----------------------------- | ------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `disable_carousel_for_styles` | `[]`    | any style in this array will not have the carousel Fields enabled. If you want to hide the extension fields for the default style, consider adding a default style `default` to the defaults | 

--- a/src/Extension/UseCarouselExtension.php
+++ b/src/Extension/UseCarouselExtension.php
@@ -33,6 +33,11 @@ class UseCarouselExtension extends DataExtension
     ];
 
     /**
+     * @config
+     */
+    private static $disable_carousel_for_styles = [];
+
+    /**
      * updateCMSFields
      *
      * @param  FieldList $fields the original fields
@@ -44,24 +49,28 @@ class UseCarouselExtension extends DataExtension
             'UseCarousel',
             'UseCarouselAutoplay'
         ]);
-        $carouselField = CheckboxField::create(
-            'UseCarousel',
-            _t(__CLASS__ . '.USECAROUSEL', 'Display as Carousel')
-        );
-        $carouselField->setDescription(
-            _t(__CLASS__ . '.USECAROUSELDESC', 'If enabled, cards that would be displayed in a new row are displayed in a carousel.')
-        );
-        $fields->insertAfter('Title', $carouselField);
+        $owner = $this->getOwner();
+        $hiddenInStyles = $owner->config()->get('disable_carousel_for_styles');
+        if (is_null($hiddenInStyles) || !in_array($owner->Style, $hiddenInStyles)) {
+            $carouselField = CheckboxField::create(
+                'UseCarousel',
+                _t(__CLASS__ . '.USECAROUSEL', 'Display as Carousel')
+            );
+            $carouselField->setDescription(
+                _t(__CLASS__ . '.USECAROUSELDESC', 'If enabled, cards that would be displayed in a new row are displayed in a carousel.')
+            );
+            $fields->insertAfter('Title', $carouselField);
 
-        $autoplayField = CheckboxField::create(
-            'UseCarouselAutoplay',
-            _t(__CLASS__ . '.AUTOPLAY', 'Enable Autoplay')
-        );
-        $autoplayField->setDescription(
-            _t(__CLASS__ . '.AUTOPLAYDESC', 'If enabled, the carousel will automatically rotate.')
-        );
-        $autoplayField->displayIf('UseCarousel')->isChecked();
-        $fields->insertAfter('UseCarousel', $autoplayField);
+            $autoplayField = CheckboxField::create(
+                'UseCarouselAutoplay',
+                _t(__CLASS__ . '.AUTOPLAY', 'Enable Autoplay')
+            );
+            $autoplayField->setDescription(
+                _t(__CLASS__ . '.AUTOPLAYDESC', 'If enabled, the carousel will automatically rotate.')
+            );
+            $autoplayField->displayIf('UseCarousel')->isChecked();
+            $fields->insertAfter('UseCarousel', $autoplayField);
+        }
         return $fields;
     }
 }


### PR DESCRIPTION
Goal: We want to allow themes to selectively display/hide the carousel-specific fields for specific styles.